### PR TITLE
Align URL formatting with v1.0.0 and update README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You need to create an "API Client" with authorization to use the
 See the "Get Started" section of [Reporting API v1](https://developer.akamai.com/api/core_features/reporting/v1.html) 
 which says, "To enable this API, choose the API service named reporting-api, and set the access level to READ-WRITE".
 
-Follow directions at [Authenticate With EdgeGrid](https://developer.akamai.com/getting-started/edgegrid) to generate 
+Follow directions at [Authenticate With EdgeGrid](https://techdocs.akamai.com/developer/docs/edgegrid) to generate 
 the required client credentials.
 
 A customized version of those directions follows:
@@ -44,7 +44,7 @@ A customized version of those directions follows:
   
 The credentials will later be entered into "Akamai Edge DNS Datasource" configuration.
 
-Note that Step 2 in [Authenticate With EdgeGrid](https://developer.akamai.com/getting-started/edgegrid) 
+Note that Step 2 in [Authenticate With EdgeGrid](https://techdocs.akamai.com/developer/docs/edgegrid) 
 "Decide which tool you’ll use to make requests" is not necessary. "Akamai Edge DNS Datasource" makes 
 the requests.
 
@@ -195,7 +195,7 @@ t=2021-03-24T10:31:09-0400 lvl=info msg="Registering plugin" logger=plugins id=a
 [Troubleshooting](https://grafana.com/docs/grafana/latest/troubleshooting/) contains troubleshooting tips.
 
 ### Log in to Grafana
-[Getting started with Grafana](https://grafana.com/docs/grafana/latest/getting-started/getting-started/)
+[Getting started with Grafana](https://grafana.com/docs/grafana/latest/fundamentals/getting-started/)
 describes how to log in to Grafana.  The default username/password are: admin/admin.
 
 ## "Akamai Edge DNS Datasource" Configuration

--- a/pkg/edgedns.go
+++ b/pkg/edgedns.go
@@ -216,8 +216,8 @@ func edgeDnsOpenApiHealthCheck(clientSecret string, host string, accessToken str
 	/*openurl := createOpenUrl(fromRounded, toRounded, interval) // The URL
 	log.DefaultLogger.Info("edgeDnsOpenApiHealthCheck", "openurl", openurl)*/
 
-	path := createOpenUrl(fromRounded, toRounded, interval)
-	openurl := fmt.Sprintf("https://%s%s", host, path)
+	openurl := createOpenUrl(fromRounded, toRounded, interval)
+	//openurl := fmt.Sprintf("https://%s%s", host, path)
 	log.DefaultLogger.Info("edgeDnsOpenApiQuery", "fullUrl", openurl)
 
 	config := NewEdgegridConfig(clientSecret, host, accessToken, clientToken)
@@ -243,6 +243,7 @@ func edgeDnsOpenApiHealthCheck(clientSecret string, host string, accessToken str
 		log.DefaultLogger.Error("OPEN API communication error", "err", err)
 		return err.Error(), backend.HealthStatusError
 	}
+	defer resp.Body.Close()
 
 	log.DefaultLogger.Info("edgeDnsOpenApiHead", "Status", resp.Status)
 
@@ -270,8 +271,8 @@ func edgeDnsOpenApiQuery(zoneNamesList []string, fromRounded time.Time, toRounde
 	reqDto := NewEdgeDnsTrafficByTimeReqDto(zoneNamesList) // the POST body
 	/*openurl := createOpenUrl(fromRounded, toRounded, interval) // the POST URL
 	log.DefaultLogger.Info("edgeDnsOpenApiQuery", "openurl", openurl)*/
-	path := createOpenUrl(fromRounded, toRounded, interval)
-	openurl := fmt.Sprintf("https://%s%s", host, path)
+	openurl := createOpenUrl(fromRounded, toRounded, interval)
+	//openurl := fmt.Sprintf("https://%s%s", host, path)
 	log.DefaultLogger.Info("edgeDnsOpenApiQuery", "fullUrl", openurl)
 
 	// POST to the OPEN API
@@ -283,7 +284,7 @@ func edgeDnsOpenApiQuery(zoneNamesList []string, fromRounded time.Time, toRounde
 	config := NewEdgegridConfig(clientSecret, host, accessToken, clientToken)
 	sess, err := session.New(
 		session.WithSigner(config),
-		session.WithHTTPTracing(true),
+		//session.WithHTTPTracing(true),
 	)
 	if err != nil {
 		log.DefaultLogger.Error("Error creating session", "err", err)


### PR DESCRIPTION
- Matched URL formatting in pkg/edgedns.go to the previous v1.0.0 release for consistency.
- Updated outdated links in the README to reflect the correct URLs.